### PR TITLE
chore(route): migrate Profile & Settings to RouteNames (Batch 2)

### DIFF
--- a/lib/screens/profile/views/profile_screen.dart
+++ b/lib/screens/profile/views/profile_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_svg/svg.dart';
 import 'package:shop/components/list_tile/divider_list_tile.dart';
 import 'package:shop/components/network_image_with_loader.dart';
 import 'package:shop/constants.dart';
-import 'package:shop/route/screen_export.dart';
+import 'package:shop/route/route_names.dart';
 
 import 'components/profile_card.dart';
 import 'components/profile_menu_item_list_tile.dart';
@@ -23,7 +23,7 @@ class ProfileScreen extends StatelessWidget {
             // proLableText: "Sliver",
             // isPro: true, if the user is pro
             press: () {
-              Navigator.pushNamed(context, userInfoScreenRoute);
+              Navigator.pushNamed(context, RouteNames.userInfo);
             },
           ),
           Padding(
@@ -51,7 +51,7 @@ class ProfileScreen extends StatelessWidget {
             text: "Orders",
             svgSrc: "assets/icons/Order.svg",
             press: () {
-              Navigator.pushNamed(context, ordersScreenRoute);
+              Navigator.pushNamed(context, RouteNames.orders);
             },
           ),
           ProfileMenuListTile(
@@ -68,21 +68,21 @@ class ProfileScreen extends StatelessWidget {
             text: "Addresses",
             svgSrc: "assets/icons/Address.svg",
             press: () {
-              Navigator.pushNamed(context, addressesScreenRoute);
+              Navigator.pushNamed(context, RouteNames.addresses);
             },
           ),
           ProfileMenuListTile(
             text: "Payment",
             svgSrc: "assets/icons/card.svg",
             press: () {
-              Navigator.pushNamed(context, emptyPaymentScreenRoute);
+              Navigator.pushNamed(context, RouteNames.emptyPayment);
             },
           ),
           ProfileMenuListTile(
             text: "Wallet",
             svgSrc: "assets/icons/Wallet.svg",
             press: () {
-              Navigator.pushNamed(context, walletScreenRoute);
+              Navigator.pushNamed(context, RouteNames.wallet);
             },
           ),
           const SizedBox(height: defaultPadding),
@@ -99,14 +99,14 @@ class ProfileScreen extends StatelessWidget {
             title: "Notification",
             trilingText: "Off",
             press: () {
-              Navigator.pushNamed(context, enableNotificationScreenRoute);
+              Navigator.pushNamed(context, RouteNames.enableNotifications);
             },
           ),
           ProfileMenuListTile(
             text: "Preferences",
             svgSrc: "assets/icons/Preferences.svg",
             press: () {
-              Navigator.pushNamed(context, preferencesScreenRoute);
+              Navigator.pushNamed(context, RouteNames.preferences);
             },
           ),
           const SizedBox(height: defaultPadding),
@@ -122,7 +122,7 @@ class ProfileScreen extends StatelessWidget {
             text: "Language",
             svgSrc: "assets/icons/Language.svg",
             press: () {
-              Navigator.pushNamed(context, selectLanguageScreenRoute);
+              Navigator.pushNamed(context, RouteNames.selectLanguage);
             },
           ),
           ProfileMenuListTile(
@@ -143,7 +143,7 @@ class ProfileScreen extends StatelessWidget {
             text: "Get Help",
             svgSrc: "assets/icons/Help.svg",
             press: () {
-              Navigator.pushNamed(context, getHelpScreenRoute);
+              Navigator.pushNamed(context, RouteNames.getHelp);
             },
           ),
           ProfileMenuListTile(


### PR DESCRIPTION
Batch 2 of Issue #10: Migrate Profile & Settings navigation to canonical RouteNames.

This PR contains small, focused changes:
- Replaced deprecated route constants with  in .

Checks:
- vm.swappiness = 90
Analyzing flutter-storefront-v2...                              

   info • 'searchScreenRoute' is deprecated and shouldn't be used. Use RouteNames.search • lib/entry_point.dart:58:44 • deprecated_member_use_from_same_package
   info • 'notificationsScreenRoute' is deprecated and shouldn't be used. Use RouteNames.notifications • lib/entry_point.dart:70:44 • deprecated_member_use_from_same_package
   info • 'onbordingScreenRoute' is deprecated and shouldn't be used. Use RouteNames.onboarding • lib/main.dart:26:21 • deprecated_member_use_from_same_package
   info • 'passwordRecoveryScreenRoute' is deprecated and shouldn't be used. Use RouteNames.passwordRecovery • lib/screens/auth/views/login_screen.dart:49:38 • deprecated_member_use_from_same_package
   info • 'entryPointScreenRoute' is deprecated and shouldn't be used. Use RouteNames.entryPoint • lib/screens/auth/views/login_screen.dart:63:29 • deprecated_member_use_from_same_package
   info • 'logInScreenRoute' is deprecated and shouldn't be used. Use RouteNames.login • lib/screens/auth/views/login_screen.dart:64:49 • deprecated_member_use_from_same_package
   info • 'signUpScreenRoute' is deprecated and shouldn't be used. Use RouteNames.signup • lib/screens/auth/views/login_screen.dart:75:56 • deprecated_member_use_from_same_package
   info • 'termsOfServicesScreenRoute' is deprecated and shouldn't be used. Use RouteNames.termsOfServices • lib/screens/auth/views/signup_screen.dart:61:50 • deprecated_member_use_from_same_package
   info • 'entryPointScreenRoute' is deprecated and shouldn't be used. Use RouteNames.entryPoint • lib/screens/auth/views/signup_screen.dart:84:52 • deprecated_member_use_from_same_package
   info • 'logInScreenRoute' is deprecated and shouldn't be used. Use RouteNames.login • lib/screens/auth/views/signup_screen.dart:94:56 • deprecated_member_use_from_same_package
   info • 'logInScreenRoute' is deprecated and shouldn't be used. Use RouteNames.login • lib/screens/onbording/views/onbording_screnn.dart:80:50 • deprecated_member_use_from_same_package
   info • 'logInScreenRoute' is deprecated and shouldn't be used. Use RouteNames.login • lib/screens/onbording/views/onbording_screnn.dart:128:56 • deprecated_member_use_from_same_package
   info • 'entryPointScreenRoute' is deprecated and shouldn't be used. Use RouteNames.entryPoint • lib/screens/product/views/added_to_cart_message_screen.dart:39:48 • deprecated_member_use_from_same_package shows only remaining, expected deprecation infos for other areas.
- vm.swappiness = 90
00:00 +0: loading /home/devmahnx/Dev/E-commerce-Complete-Flutter-UI/flutter-storefront-v2/test/widget_test.dart                                                                                        00:01 +0: loading /home/devmahnx/Dev/E-commerce-Complete-Flutter-UI/flutter-storefront-v2/test/widget_test.dart                                                                                        00:02 +0: loading /home/devmahnx/Dev/E-commerce-Complete-Flutter-UI/flutter-storefront-v2/test/widget_test.dart                                                                                        00:02 +0: /home/devmahnx/Dev/E-commerce-Complete-Flutter-UI/flutter-storefront-v2/test/widget_test.dart: App builds and stabilizes                                                                     00:02 +1: /home/devmahnx/Dev/E-commerce-Complete-Flutter-UI/flutter-storefront-v2/test/widget_test.dart: App builds and stabilizes                                                                     00:02 +2: /home/devmahnx/Dev/E-commerce-Complete-Flutter-UI/flutter-storefront-v2/test/widget_test.dart: App builds and stabilizes                                                                     00:03 +2: /home/devmahnx/Dev/E-commerce-Complete-Flutter-UI/flutter-storefront-v2/test/widget_test.dart: App builds and stabilizes                                                                     00:03 +3: /home/devmahnx/Dev/E-commerce-Complete-Flutter-UI/flutter-storefront-v2/test/widget_test.dart: App builds and stabilizes                                                                     00:03 +3: All tests passed!                                                                                                                                                                             passes locally.

Please review and let me know if you'd prefer this as draft or ready.
