### PR TITLE
[infra] Update Gradle wrapper to 8.11.1 for Flutter 3.38.5 compatibility

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip


### PR DESCRIPTION
**Critical build fix:** Updates Gradle wrapper from 7.6.3 to 8.11.1 to resolve Kotlin compilation errors in Flutter 3.38.5.

Without this fix, `flutter run` fails with unresolved Kotlin references in the Flutter tools' Gradle plugin.

- Gradle: 7.6.3 → 8.11.1
- Compatible with: Kotlin 1.9.20 (set in settings.gradle)
- Resolves: Build failures in Flutter 3.38.5

Tested: `flutter analyze` ✅ | `flutter test` ✅