### PR TITLE
feat(#11): ProviderScope + ProductRepository toggle

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shop/route/route_names.dart';
 import 'package:shop/route/router.dart' as router;
 import 'package:shop/theme/app_theme.dart';
 
 void main() {
-  runApp(const MyApp());
+  // Use ProviderScope to enable Riverpod providers across the app.
+  runApp(const ProviderScope(child: MyApp()));
 }
 
 // Thanks for using our template. You are using the free version of the template.

--- a/lib/providers/repository_providers.dart
+++ b/lib/providers/repository_providers.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shop/repository/product_repository.dart';
+
+// Toggle: set at compile time using --dart-define=USE_MOCK=true/false
+const bool _useMock = bool.fromEnvironment('USE_MOCK', defaultValue: true);
+
+final productRepositoryProvider = Provider<ProductRepository>((ref) {
+  if (_useMock) {
+    return MockProductRepository();
+  }
+  return RealProductRepository();
+});

--- a/lib/repository/product_repository.dart
+++ b/lib/repository/product_repository.dart
@@ -1,0 +1,30 @@
+// Minimal ProductRepository abstraction and two simple implementations
+class Product {
+  final String id;
+  final String title;
+
+  Product({required this.id, required this.title});
+}
+
+abstract class ProductRepository {
+  Future<List<Product>> fetchProducts();
+}
+
+class MockProductRepository implements ProductRepository {
+  @override
+  Future<List<Product>> fetchProducts() async {
+    // return a tiny, deterministic list for tests and local dev
+    return [
+      Product(id: 'p1', title: 'Mock Product 1'),
+      Product(id: 'p2', title: 'Mock Product 2'),
+    ];
+  }
+}
+
+class RealProductRepository implements ProductRepository {
+  @override
+  Future<List<Product>> fetchProducts() async {
+    // Placeholder for real network implementation. For now return empty list.
+    return [];
+  }
+}

--- a/test/product_repository_test.dart
+++ b/test/product_repository_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shop/providers/repository_providers.dart';
+import 'package:shop/repository/product_repository.dart';
+
+void main() {
+  test('productRepository provider returns a ProductRepository and can fetch mock products when overridden', () async {
+    final container = ProviderContainer(overrides: [
+      productRepositoryProvider.overrideWithValue(MockProductRepository()),
+    ]);
+    addTearDown(container.dispose);
+
+    final repo = container.read(productRepositoryProvider);
+    expect(repo, isA<ProductRepository>());
+
+    final products = await repo.fetchProducts();
+    expect(products, isNotEmpty);
+    expect(products.first.id, equals('p1'));
+  });
+
+  test('can override provider with RealProductRepository stub', () async {
+    final container = ProviderContainer(overrides: [
+      productRepositoryProvider.overrideWithValue(RealProductRepository()),
+    ]);
+    addTearDown(container.dispose);
+
+    final repo = container.read(productRepositoryProvider);
+    expect(repo, isA<ProductRepository>());
+
+    final products = await repo.fetchProducts();
+    expect(products, isA<List<Product>>());
+  });
+}


### PR DESCRIPTION
Implements ProviderScope at app root and adds a small ProductRepository abstraction with mock and real stubs. Toggle between mock/real with --dart-define=USE_MOCK=true|false. Includes unit tests for provider resolution. Small, reviewable change.